### PR TITLE
restore the keepLog to false when the build is demoted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,13 @@
-target
 .classpath
 .project
-.settings
+/target
+/target/work
+/work
+/bin
+/.settings
+/pom.xml.releaseBackup
+/release.properties
+/settings.xml
+*.unc-backup~
+*.uncrustify
+*.sw?

--- a/pom.xml
+++ b/pom.xml
@@ -1,57 +1,51 @@
+<?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-
-    <parent>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>plugin</artifactId>
-        <version>1.398</version>
-    </parent>
-
-    <artifactId>promoted-builds-simple</artifactId>
-    <packaging>hpi</packaging>
-    <name>Promoted Builds (Simple)</name>
-    <version>1.10-SNAPSHOT</version>
-    <url>http://wiki.jenkins-ci.org/display/JENKINS/Promoted+Builds+Simple+Plugin</url>
-
-    <developers>
-      <developer>
-        <id>mindless</id>
-        <name>Alan Harder</name>
-      </developer>
-    </developers>
-
-    <dependencies>
-      <dependency>
-        <groupId>${project.groupId}</groupId>
-        <artifactId>copyartifact</artifactId>
-        <version>[1.14,)</version>
-        <optional>true</optional>
-      </dependency>
-      <dependency>
-        <groupId>org.jenkins-ci.main</groupId>
-        <artifactId>maven-plugin</artifactId>
-        <optional>true</optional>
-      </dependency>
-    </dependencies>
-
-    <repositories>
-        <repository>
-            <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
-        </repository>
-    </repositories>
-  
-    <scm>
-      <connection>scm:git:git://github.com/jenkinsci/promoted-builds-simple-plugin.git</connection>
-      <developerConnection>scm:git:git@github.com:jenkinsci/promoted-builds-simple-plugin.git</developerConnection>
-      <url>https://github.com/jenkinsci/promoted-builds-simple-plugin</url>
-    </scm>
-
-    <pluginRepositories>
-        <pluginRepository>
-            <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
-        </pluginRepository>
-    </pluginRepositories>
-</project>  
-
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
+    <version>1.398</version>
+  </parent>
+  <artifactId>promoted-builds-simple</artifactId>
+  <packaging>hpi</packaging>
+  <name>Promoted Builds (Simple)</name>
+  <version>1.10-SNAPSHOT</version>
+  <url>http://wiki.jenkins-ci.org/display/JENKINS/Promoted+Builds+Simple+Plugin</url>
+  <developers>
+    <developer>
+      <id>mindless</id>
+      <name>Alan Harder</name>
+    </developer>
+  </developers>
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>copyartifact</artifactId>
+      <version>[1.14,)</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.main</groupId>
+      <artifactId>maven-plugin</artifactId>
+      <optional>true</optional>
+      <version>[1.533,)</version>
+    </dependency>
+  </dependencies>
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>http://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
+  <scm>
+    <connection>scm:git:git://github.com/jenkinsci/promoted-builds-simple-plugin.git</connection>
+    <developerConnection>scm:git:git@github.com:jenkinsci/promoted-builds-simple-plugin.git</developerConnection>
+    <url>https://github.com/jenkinsci/promoted-builds-simple-plugin</url>
+  </scm>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>http://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.398</version>
+    <version>1.460</version>
   </parent>
   <artifactId>promoted-builds-simple</artifactId>
   <packaging>hpi</packaging>
@@ -17,6 +17,11 @@
       <name>Alan Harder</name>
     </developer>
   </developers>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <version.jdk>1.6</version.jdk>
+    <version.maven-hpi-plugin>1.74</version.maven-hpi-plugin>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -28,9 +33,22 @@
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>maven-plugin</artifactId>
       <optional>true</optional>
-      <version>[1.533,)</version>
+      <version>[1.73,)</version>
     </dependency>
   </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jenkins-ci.tools</groupId>
+        <artifactId>maven-hpi-plugin</artifactId>
+        <version>${version.maven-hpi-plugin}</version>
+        <configuration>
+          <source>${version.jdk}</source>
+          <target>${version.jdk}</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>

--- a/src/main/java/hudson/plugins/promoted_builds_simple/PromoteAction.java
+++ b/src/main/java/hudson/plugins/promoted_builds_simple/PromoteAction.java
@@ -78,6 +78,8 @@ public class PromoteAction implements BuildBadgeAction {
         levelValue = Integer.parseInt(req.getParameter("level"));
         if (levelValue == 0) {
             level = icon = null;
+            // clear keepLog setting when the build demoted
+            req.findAncestorObject(Run.class).keepLog(false);
             req.findAncestorObject(Run.class).save();
         } else {
             PromotionLevel src = getAllPromotionLevels().get(levelValue - 1);


### PR DESCRIPTION
This commit restores keepLog to 'false' when the build is  demoted  - promoted to 'None
