### PR TITLE
[JENKINS-29767] `selector` should not be used in config.jelly

### DIFF
--- a/src/main/resources/hudson/plugins/promoted_builds_simple/PromotedBuildSelector/config.jelly
+++ b/src/main/resources/hudson/plugins/promoted_builds_simple/PromotedBuildSelector/config.jelly
@@ -28,9 +28,9 @@ THE SOFTWARE.
                                  method="getAllPromotionLevels"/>
     <select name="level" class="setting-input">
       <j:forEach var="level" indexVar="i" items="${levels}">
-        <f:option value="${i+1}" selected="${selector.level == i+1}">${level.name}</f:option>
+        <f:option value="${i+1}" selected="${instance.level == i+1}">${level.name}</f:option>
       </j:forEach>
-      <f:option value="0" selected="${selector.level == 0}">${%fromParameter}</f:option>
+      <f:option value="0" selected="${instance.level == 0}">${%fromParameter}</f:option>
     </select>
   </f:entry>
 </j:jelly>


### PR DESCRIPTION
[JENKINS-29767](https://issues.jenkins-ci.org/browse/JENKINS-29767)

`PromotedBuildSelector` no longer preserves its configuration in the project configuration pages with copyartifact-1.35.2.
This is for copyartifact no longer uses its own jelly tag and no longer provides `selector` for subclasses of `BuildSelector`.
`selector` is considered as an internal variable of copyartifact and other plugins shouldn't use that. They should standard `instance` instead.

This change makes promoted-build-simple-plugin use `instance` instead of `selector` and adds a test for that.
